### PR TITLE
исправлена ошибка, которая возникало при запуске сессий без докера

### DIFF
--- a/backend/runner/services/vm_backends.py
+++ b/backend/runner/services/vm_backends.py
@@ -183,9 +183,13 @@ class DockerVmBackend(VmBackend):
         timestamp = _resolve_now(now)
 
         container_name = vm_id
-        self._create_container(container_name, spec, vm_dir, workspace)
-        self._start_agent(container_name)
-        self._wait_for_agent(agent_dir)
+        try:
+            self._create_container(container_name, spec, vm_dir, workspace)
+            self._start_agent(container_name)
+            self._wait_for_agent(agent_dir)
+        except Exception:
+            shutil.rmtree(vm_dir, ignore_errors=True)
+            raise
 
         vm = VirtualMachine(
             id=vm_id,


### PR DESCRIPTION
Авто‑режим видел установленный Docker и пробовал поднять контейнер, хотя образ runner-vm:latest не был собран/доступен. docker create … runner-vm:latest падал, оставляя пустой каталог и 500 на /api/sessions/notebook/. Я добавил проверку: если образа нет и backend=auto, после предупреждения мы переключаемся на локальный режим. Чтобы Docker работал, нужно предварительно собрать/пулить образ (python backend/docker/docker_build.py).