### PR TITLE
[codex] add open contest solvers to results

### DIFF
--- a/backend/runner/api/serializers/submissions.py
+++ b/backend/runner/api/serializers/submissions.py
@@ -8,6 +8,7 @@ from ...models.submission import Submission
 from ...models.problem import Problem
 from ...models.contest import Contest
 from ...models.prevalidation import PreValidation
+from ...models.course import CourseParticipant
 from ...services.problem_scoring import (
     default_curve_p,
     extract_raw_metric,
@@ -70,6 +71,18 @@ def _extract_submission_score(submission: Submission):
         curve_p=nonlinear_curve,
     )
     return float(score_100)
+
+
+def _ensure_submitter_is_listed_in_contest(contest: Contest | None, user) -> None:
+    if contest is None or not getattr(user, "is_authenticated", False):
+        return
+    if contest.is_user_manager(user):
+        return
+    if CourseParticipant.objects.filter(course=contest.course, user=user).exists():
+        return
+    if contest.allowed_participants.filter(pk=user.pk).exists():
+        return
+    contest.allowed_participants.add(user)
 
 
 class SubmissionCreateSerializer(serializers.ModelSerializer):
@@ -160,7 +173,7 @@ class SubmissionCreateSerializer(serializers.ModelSerializer):
         user = request.user
         problem_id = validated_data.pop("problem_id")
         validated_data.pop("contest_id", None)
-        validated_data.pop("_contest", None)
+        contest = validated_data.pop("_contest", None)
         raw_text = validated_data.get("raw_text")
 
         try:
@@ -176,6 +189,7 @@ class SubmissionCreateSerializer(serializers.ModelSerializer):
             validated_data["source"] = Submission.SOURCE_FILE
 
         submission = Submission.objects.create(user=user, problem=problem, **validated_data)
+        _ensure_submitter_is_listed_in_contest(contest, user)
         return submission
 
 

--- a/backend/runner/api/views/test_submissions.py
+++ b/backend/runner/api/views/test_submissions.py
@@ -177,6 +177,33 @@ class SubmissionAPITests(TestCase):
 
     @override_settings(MEDIA_ROOT=tempfile.gettempdir())
     @patch("runner.api.views.submissions.enqueue_submission_for_evaluation")
+    def test_open_contest_submission_adds_external_user_to_allowed_participants(self, mock_enqueue):
+        outsider = User.objects.create_user(username="outsider_submitter", password="pass")
+        self.client.logout()
+        self.client.login(username="outsider_submitter", password="pass")
+
+        self.course.is_open = True
+        self.course.save(update_fields=["is_open"])
+        self.contest.start_time = timezone.now() - timedelta(minutes=30)
+        self.contest.duration_minutes = 120
+        self.contest.allow_upsolving = False
+        self.contest.save(update_fields=["start_time", "duration_minutes", "allow_upsolving"])
+
+        resp = self.client.post(
+            self.url,
+            {
+                "problem_id": self.problem.id,
+                "contest_id": self.contest.id,
+                "raw_text": "id,pred\n1,0.1\n",
+            },
+        )
+
+        self.assertEqual(resp.status_code, 201)
+        self.assertTrue(self.contest.allowed_participants.filter(pk=outsider.pk).exists())
+        self.assertTrue(mock_enqueue.called)
+
+    @override_settings(MEDIA_ROOT=tempfile.gettempdir())
+    @patch("runner.api.views.submissions.enqueue_submission_for_evaluation")
     @patch("runner.services.validation_service.run_pre_validation")
     def test_enqueue_only_if_valid(self, mock_validate, mock_enqueue):
         mock_preval = mock.Mock()


### PR DESCRIPTION
## Что изменилось
- при отправке решения с contest_id пользователь автоматически добавляется в список allowed_participants выбранного контеста, если он не менеджер контеста и ещё не состоит в курсе или в списке разрешённых участников
- добавлен тест на сценарий открытого контеста, где внешний пользователь решает задачу и должен появиться в таблице результатов

## Почему это нужно
Issue #725: пользователь мог решать задачи из открытого контеста без регистрации, но не попадал в таблицу результатов.

## Корневая причина
Лидерборд строился только по участникам курса и allowed_participants, а отправка решения в открытый контест не добавляла такого пользователя ни в одну из этих групп.

## Эффект для пользователей
Пользователь, решивший задачу в открытом контесте, теперь будет появляться в таблице результатов и сможет сравнивать свой прогресс с остальными.

## Проверка
- синтаксическая проверка изменённых Python-файлов через compile()
- попытка запустить Django tests для этого сценария была заблокирована окружением: локально недоступен PostgreSQL, а Docker Desktop не запущен