### PR TITLE
[codex] fix polygon publish flow

### DIFF
--- a/frontend/src/api/polygon.js
+++ b/frontend/src/api/polygon.js
@@ -22,5 +22,5 @@ export function uploadPolygonProblemFiles(problemId, formData) {
 }
 
 export function publishPolygonProblem(problemId) {
-    return apiPost(`backend/polygon/problems/${problemId}/publish`)
+    return apiPost(`backend/polygon/problems/${problemId}/publish`, {})
 }

--- a/frontend/src/pages/PolygonProblemEditPage.vue
+++ b/frontend/src/pages/PolygonProblemEditPage.vue
@@ -24,7 +24,7 @@
             v-if="!problem?.is_published"
             class="button button--primary" 
             @click="publishProblem"
-            :disabled="publishing"
+            :disabled="publishing || saving || uploading"
           >
             {{ publishing ? 'Публикация...' : 'Опубликовать' }}
           </button>
@@ -554,7 +554,7 @@
             v-if="!problem?.is_published"
             class="button button--primary" 
             @click="publishProblem"
-            :disabled="publishing"
+            :disabled="publishing || saving || uploading"
           >
             {{ publishing ? 'Публикация...' : 'Опубликовать' }}
           </button>
@@ -1035,8 +1035,7 @@ const loadProblem = async () => {
   }
 }
 
-const saveProblem = async () => {
-  clearMessages()
+const persistProblem = async ({ showSuccessMessage = true } = {}) => {
   saving.value = true
   
   try {
@@ -1061,8 +1060,11 @@ const saveProblem = async () => {
     // Update problem data
     problem.value = { ...problem.value, ...data }
     
-    successMessage.value = 'Задача успешно сохранена'
-    setTimeout(() => { successMessage.value = null }, 3000)
+    if (showSuccessMessage) {
+      successMessage.value = 'Задача успешно сохранена'
+      setTimeout(() => { successMessage.value = null }, 3000)
+    }
+    return data
   } catch (err) {
     console.error('Failed to save problem', err)
     
@@ -1082,9 +1084,15 @@ const saveProblem = async () => {
     } else {
       errorMessage.value = 'Не удалось сохранить задачу'
     }
+    throw err
   } finally {
     saving.value = false
   }
+}
+
+const saveProblem = async () => {
+  clearMessages()
+  await persistProblem()
 }
 
 const handleFileSelect = (fieldName, event) => {
@@ -1092,8 +1100,11 @@ const handleFileSelect = (fieldName, event) => {
   selectedFiles[fieldName] = file || null
 }
 
-const uploadFiles = async () => {
-  clearMessages()
+const persistFiles = async ({ showSuccessMessage = true } = {}) => {
+  if (!hasSelectedFiles.value) {
+    return null
+  }
+
   uploading.value = true
   
   try {
@@ -1121,14 +1132,23 @@ const uploadFiles = async () => {
     // Reset file input elements
     Object.values(fileInputRefs).forEach(r => { if (r.value) r.value.value = '' })
     
-    successMessage.value = 'Файлы успешно загружены'
-    setTimeout(() => { successMessage.value = null }, 3000)
+    if (showSuccessMessage) {
+      successMessage.value = 'Файлы успешно загружены'
+      setTimeout(() => { successMessage.value = null }, 3000)
+    }
+    return data
   } catch (err) {
     console.error('Failed to upload files', err)
     errorMessage.value = 'Не удалось загрузить файлы. Проверьте формат файлов.'
+    throw err
   } finally {
     uploading.value = false
   }
+}
+
+const uploadFiles = async () => {
+  clearMessages()
+  await persistFiles()
 }
 
 const publishProblem = async () => {
@@ -1137,9 +1157,14 @@ const publishProblem = async () => {
   
   try {
     const problemId = route.params.id
+    await persistProblem({ showSuccessMessage: false })
+    await persistFiles({ showSuccessMessage: false })
     const data = await publishPolygonProblem(problemId)
     
-    problem.value.is_published = true
+    problem.value = {
+      ...problem.value,
+      is_published: true,
+    }
     successMessage.value = data.message || 'Задача успешно опубликована'
     setTimeout(() => { successMessage.value = null }, 5000)
   } catch (err) {


### PR DESCRIPTION
﻿## Что изменилось
- кнопка «Опубликовать» в редакторе Polygon теперь перед публикацией сначала сохраняет актуальные поля задачи
- если пользователь выбрал новые файлы, публикация сначала загружает их, а потом вызывает publish API
- фронтовый вызов publish теперь отправляет явный пустой payload, чтобы POST-контракт был однозначным
- кнопка публикации блокируется, пока идёт сохранение или загрузка файлов

## Почему это нужно
Issue #686: кнопка публикации в Полигоне не работала в реальном пользовательском сценарии редактирования.

## Корневая причина
Публикация вызывалась напрямую по уже сохранённому состоянию задачи, без предварительного сохранения формы и без загрузки выбранных, но ещё не отправленных файлов. Из-за этого сервер проверял устаревшие данные и публикация с точки зрения пользователя «не работала».

## Эффект для пользователей
После заполнения полей и выбора файлов пользователь может сразу нажать «Опубликовать», и страница сама доведёт задачу до валидного состояния перед публикацией.

## Проверка
- `npm run build` в `frontend` прошёл успешно
- `npm run test:unit` завершился без ошибок; тестовых файлов в проекте сейчас нет
