### PR TITLE
[codex] Add CPU/GPU toggle to notebooks

### DIFF
--- a/backend/runner/urls.py
+++ b/backend/runner/urls.py
@@ -144,6 +144,7 @@ urlpatterns = [
     path('notebook/<int:notebook_id>/', notebook_detail, name='notebook_detail'),
     path('backend/notebook/<int:notebook_id>/', notebook_detail_api, name='backend_notebook_detail'),
     path('backend/notebook/<int:notebook_id>/rename/', rename_notebook, name='backend_rename_notebook'),
+    path('backend/notebook/<int:notebook_id>/device/', update_notebook_device, name='backend_update_notebook_device'),
     path('backend/notebook/<int:notebook_id>/delete/', delete_notebook, name='backend_delete_notebook'),
     path('backend/notebook/<int:notebook_id>/cell/<int:cell_id>/save_output/', save_cell_output, name='backend_save_cell_output'),
     path('backend/notebook/<int:notebook_id>/cell/<int:cell_id>/save_text/', save_text_cell, name='backend_save_text_cell'),

--- a/backend/runner/views/test_update_notebook_device.py
+++ b/backend/runner/views/test_update_notebook_device.py
@@ -1,0 +1,41 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from ..models import Notebook
+
+
+class UpdateNotebookDeviceViewTests(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+        self.user = get_user_model().objects.create_user(username="device-user", password="pass")
+        self.notebook = Notebook.objects.create(owner=self.user, title="Notebook")
+        self.client.force_login(self.user)
+
+    def test_backend_alias_updates_compute_device(self):
+        response = self.client.patch(
+            reverse("runner:backend_update_notebook_device", args=[self.notebook.id]),
+            data=json.dumps({"compute_device": "gpu"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "success")
+        self.assertEqual(payload["compute_device"], "gpu")
+
+        self.notebook.refresh_from_db()
+        self.assertEqual(self.notebook.compute_device, Notebook.ComputeDevice.GPU)
+
+    def test_rejects_invalid_compute_device(self):
+        response = self.client.patch(
+            reverse("runner:backend_update_notebook_device", args=[self.notebook.id]),
+            data=json.dumps({"compute_device": "tpu"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.notebook.refresh_from_db()
+        self.assertEqual(self.notebook.compute_device, Notebook.ComputeDevice.CPU)

--- a/frontend/src/api/notebook.js
+++ b/frontend/src/api/notebook.js
@@ -159,6 +159,10 @@ export function renameNotebook(notebookId, title) {
     return apiPost(`/backend/notebook/${notebookId}/rename/`, { title })
 }
 
+export function updateNotebookDevice(notebookId, computeDevice) {
+    return apiPatch(`/backend/notebook/${notebookId}/device/`, { compute_device: computeDevice })
+}
+
 export function deleteNotebook(notebookId) {
     return apiPost(
         `/backend/notebook/${notebookId}/delete/`,

--- a/frontend/src/pages/NotebookPage.vue
+++ b/frontend/src/pages/NotebookPage.vue
@@ -121,7 +121,7 @@
                   class="toolbar-device-option"
                   :class="{ 'toolbar-device-option--active': currentComputeDevice === device.value }"
                   :aria-pressed="currentComputeDevice === device.value ? 'true' : 'false'"
-                  :disabled="settingsBusy"
+                  :disabled="!canChangeComputeDevice"
                   :title="deviceToggleTitle"
                   @click="saveNotebookDevice(device.value)"
                 >
@@ -673,18 +673,22 @@ const currentComputeDevice = computed(() => {
 })
 
 const deviceToggleTitle = computed(() => {
-  if (sessionStatus.value === 'running') {
+  if (sessionStatus.value === 'running' || sessionStatus.value === 'starting') {
     return 'Изменение применится после перезапуска сессии'
   }
   return 'Устройство применится при запуске сессии'
 })
 
+const canChangeComputeDevice = computed(() => {
+  return hasValidId.value && !settingsBusy.value && !sessionActionBusy.value && sessionStatus.value !== 'starting'
+})
+
 const canStartSession = computed(() => {
-  return hasValidId.value && !sessionActionBusy.value && sessionStatus.value !== 'running'
+  return hasValidId.value && !sessionActionBusy.value && !settingsBusy.value && sessionStatus.value !== 'running'
 })
 
 const canRestartSession = computed(() => {
-  return hasValidId.value && !sessionActionBusy.value && sessionStatus.value === 'running'
+  return hasValidId.value && !sessionActionBusy.value && !settingsBusy.value && sessionStatus.value === 'running'
 })
 
 const canStopSession = computed(() => {
@@ -1450,7 +1454,7 @@ const saveNotebookTitle = async () => {
 
 const saveNotebookDevice = async (device) => {
   const normalized = String(device || '').toLowerCase()
-  if (!hasValidId.value || settingsBusy.value || normalized === currentComputeDevice.value) return
+  if (!canChangeComputeDevice.value || normalized === currentComputeDevice.value) return
   if (normalized !== 'cpu' && normalized !== 'gpu') {
     deviceError.value = 'Недопустимое устройство вычислений.'
     return

--- a/frontend/src/pages/NotebookPage.vue
+++ b/frontend/src/pages/NotebookPage.vue
@@ -113,6 +113,21 @@
               </button>
             </div>
             <div class="toolbar-group toolbar-group--right">
+              <div class="toolbar-device-toggle" role="group" aria-label="Устройство выполнения блокнота">
+                <button
+                  v-for="device in computeDeviceOptions"
+                  :key="device.value"
+                  type="button"
+                  class="toolbar-device-option"
+                  :class="{ 'toolbar-device-option--active': currentComputeDevice === device.value }"
+                  :aria-pressed="currentComputeDevice === device.value ? 'true' : 'false'"
+                  :disabled="settingsBusy"
+                  :title="deviceToggleTitle"
+                  @click="saveNotebookDevice(device.value)"
+                >
+                  {{ device.label }}
+                </button>
+              </div>
               <div ref="sessionMenuRef" class="toolbar-session-wrap">
                 <button
                   type="button"
@@ -222,6 +237,7 @@
               </div>
             </div>
           </div>
+          <div v-if="deviceError" class="toolbar-error">{{ deviceError }}</div>
 
           <div class="cells-list">
             <div v-if="orderedCells.length === 0" class="cells-empty">
@@ -544,6 +560,7 @@ import {
   saveTextCell,
   startNotebookSession,
   stopNotebookSession,
+  updateNotebookDevice,
   uploadNotebookSessionFile,
 } from '@/api/notebook'
 
@@ -565,6 +582,7 @@ const sessionFiles = ref([])
 const fileInputRef = ref(null)
 const fileActionBusy = ref(false)
 const fileActionError = ref('')
+const deviceError = ref('')
 const runningCellIds = ref(new Set())
 const runAllInProgress = ref(false)
 const queuedCellRunIds = ref([])
@@ -649,6 +667,18 @@ const sessionStatusLabel = computed(() => {
   return 'не запущена'
 })
 
+const currentComputeDevice = computed(() => {
+  const device = String(notebook.value?.compute_device || '').toLowerCase()
+  return device === 'gpu' ? 'gpu' : 'cpu'
+})
+
+const deviceToggleTitle = computed(() => {
+  if (sessionStatus.value === 'running') {
+    return 'Изменение применится после перезапуска сессии'
+  }
+  return 'Устройство применится при запуске сессии'
+})
+
 const canStartSession = computed(() => {
   return hasValidId.value && !sessionActionBusy.value && sessionStatus.value !== 'running'
 })
@@ -693,6 +723,10 @@ const files = computed(() => {
 const toolbarActions = [
   { id: 'code', label: '+ Код', variant: 'primary' },
   { id: 'text', label: '+ Текст', variant: 'primary' },
+]
+const computeDeviceOptions = [
+  { value: 'cpu', label: 'CPU' },
+  { value: 'gpu', label: 'GPU' },
 ]
 const footerActions = [
   { id: 'code', label: '+ Код' },
@@ -1414,6 +1448,28 @@ const saveNotebookTitle = async () => {
   }
 }
 
+const saveNotebookDevice = async (device) => {
+  const normalized = String(device || '').toLowerCase()
+  if (!hasValidId.value || settingsBusy.value || normalized === currentComputeDevice.value) return
+  if (normalized !== 'cpu' && normalized !== 'gpu') {
+    deviceError.value = 'Недопустимое устройство вычислений.'
+    return
+  }
+
+  settingsBusy.value = true
+  deviceError.value = ''
+  try {
+    const result = await updateNotebookDevice(notebookId.value, normalized)
+    if (notebook.value) {
+      notebook.value.compute_device = result?.compute_device || normalized
+    }
+  } catch (error) {
+    deviceError.value = error?.message || 'Не удалось обновить устройство вычислений.'
+  } finally {
+    settingsBusy.value = false
+  }
+}
+
 const goToLinkedProblem = async () => {
   if (!linkedProblemId.value) return
   closeSettingsMenu()
@@ -1759,6 +1815,7 @@ const loadNotebook = async () => {
     sessionStatus.value = 'stopped'
     sessionFiles.value = []
     fileActionError.value = ''
+    deviceError.value = ''
     return
   }
 
@@ -1766,6 +1823,7 @@ const loadNotebook = async () => {
   stateMessage.value = ''
   selectedCellId.value = null
   editingTextCellId.value = null
+  deviceError.value = ''
   closeOutputMenu()
   try {
     notebook.value = await getNotebook(notebookId.value)
@@ -1793,6 +1851,7 @@ const loadNotebook = async () => {
     sessionStatus.value = 'stopped'
     sessionFiles.value = []
     fileActionError.value = ''
+    deviceError.value = ''
   }
 }
 
@@ -2103,6 +2162,48 @@ onBeforeUnmount(() => {
 
 .toolbar-session-dot--stopped {
   background: var(--color-session-stopped);
+}
+
+.toolbar-device-toggle {
+  display: inline-flex;
+  align-items: center;
+  height: 29px;
+  padding: 2px;
+  border-radius: 10px;
+  background: var(--color-button-secondary);
+  border: 1px solid var(--color-border-light);
+  gap: 2px;
+}
+
+.toolbar-device-option {
+  min-width: 42px;
+  height: 23px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--color-text-primary);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.toolbar-device-option--active {
+  background: var(--color-button-primary);
+  color: var(--color-button-text-primary);
+}
+
+.toolbar-device-option:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.toolbar-error {
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(255, 56, 60, 0.08);
+  color: var(--color-text-danger);
+  font-size: 13px;
+  line-height: 1.3;
 }
 
 


### PR DESCRIPTION
## Summary

- Add a visible CPU/GPU toggle to the notebook toolbar.
- Wire the Vue notebook page to the existing compute device update flow through a /backend/notebook/.../device/ route.
- Cover the backend alias with a focused view test for valid and invalid device updates.

## Validation

- npm run build passes with existing webpack bundle-size warnings.
- python manage.py check passes.
- python manage.py test runner.views.test_update_notebook_device --verbosity 2 could not complete because the local test database could not connect to Postgres on localhost:5432.

Closes #742