### PR TITLE
Stop notebook run-all on cell error

### DIFF
--- a/backend/runner/static/notebook/js/notebook_detail.js
+++ b/backend/runner/static/notebook/js/notebook_detail.js
@@ -534,8 +534,12 @@ const notebookDetail = {
         });
     },
 
-    enqueueCellRun(cellId) {
-        this.cellQueue.push({ cellId, enqueuedAt: Date.now() });
+    enqueueCellRun(cellId, options = {}) {
+        this.cellQueue.push({
+            cellId,
+            enqueuedAt: Date.now(),
+            stopQueueOnError: Boolean(options.stopQueueOnError),
+        });
         this.updateQueueStatuses();
         this.processQueue();
     },
@@ -557,7 +561,11 @@ const notebookDetail = {
         job.controller = controller;
         job.cancelled = false;
         this.currentRun = job;
-        this.executeQueueJob(job).finally(() => {
+        this.executeQueueJob(job).then((status) => {
+            if (job.stopQueueOnError && status === 'error') {
+                this.cellQueue = this.cellQueue.filter((queuedJob) => !queuedJob.stopQueueOnError);
+            }
+        }).finally(() => {
             const cellId = job.cellId;
             if (this.currentRun && this.currentRun.cellId === cellId) {
                 this.currentRun = null;
@@ -593,7 +601,7 @@ const notebookDetail = {
         const cellId = job.cellId;
         const cellElement = document.querySelector(`[data-cell-id="${cellId}"]`);
         if (!cellElement) {
-            return;
+            return 'skipped';
         }
         const textarea = cellElement.querySelector('textarea');
         const outputElement = document.getElementById(`output-${cellId}`);
@@ -604,7 +612,7 @@ const notebookDetail = {
 
         if (!textarea || !outputElement || (!runCellUrl && !(runCellStreamStartUrl && runCellStreamStatusUrl))) {
             this.setCellStatus(cellId, 'error');
-            return;
+            return 'error';
         }
 
         const cellNumericId = Number(cellId);
@@ -645,7 +653,7 @@ const notebookDetail = {
             }
 
             if (useStreaming) {
-                await this.executeQueueJobStreaming({
+                return await this.executeQueueJobStreaming({
                     job,
                     cellId,
                     sessionId,
@@ -716,9 +724,9 @@ const notebookDetail = {
                 const formattedOutput = NotebookUtils.formatCellRunResult(data);
                 outputElement.innerHTML = formattedOutput;
                 this.enhanceOutputElement(outputElement);
-                outputElement.className = data.error ? 'output error' : 'output success';
+                const finalStatus = (data.error || data.status === 'error') ? 'error' : 'success';
+                outputElement.className = finalStatus === 'error' ? 'output error' : 'output success';
                 this.renderArtifacts(cellId, data.artifacts || []);
-                const finalStatus = data.error ? 'error' : 'success';
                 const durationMs = Math.max(
                     0,
                     (typeof performance !== 'undefined' ? performance.now() : Date.now()) - startedAt,
@@ -727,6 +735,7 @@ const notebookDetail = {
                 this.setCellStatus(cellId, finalStatus, meta);
                 this.rememberOutputSnapshot(cellId, formattedOutput);
                 await this.saveCellState(cellId, code, formattedOutput, saveOutputUrl);
+                return finalStatus;
             }
         } catch (error) {
             if (error?.status === 400 && /Сессия не создана/i.test(error.message || '')) {
@@ -751,7 +760,7 @@ const notebookDetail = {
                     this.rememberOutputSnapshot(cellId, note);
                     await this.saveCellState(cellId, code, note, saveOutputUrl);
                 }
-                return;
+                return 'cancelled';
             }
             console.error('Ошибка выполнения ячейки:', error);
             const message = error?.message || 'Не удалось выполнить ячейку';
@@ -762,6 +771,7 @@ const notebookDetail = {
             this.setCellStatus(cellId, 'error');
             this.rememberOutputSnapshot(cellId, errorHtml);
             await this.saveCellState(cellId, code, errorHtml, saveOutputUrl);
+            return 'error';
         }
     },
 
@@ -922,7 +932,7 @@ const notebookDetail = {
                 this.setCellStatus(cellId, finalStatus, meta);
                 this.rememberOutputSnapshot(cellId, formattedOutput);
                 await this.saveCellState(cellId, code, formattedOutput, saveOutputUrl);
-                return;
+                return finalStatus;
             }
 
             await new Promise((resolve) => setTimeout(resolve, 300));
@@ -3568,7 +3578,6 @@ const runAll = function() {
         const id = cell.getAttribute('data-cell-id');
         if (!id) continue;
 
-        // запускаем так же, как запускается одиночная ячейка
-        notebookDetail.runCell(id);
+        notebookDetail.enqueueCellRun(id, { stopQueueOnError: true });
     }
 };

--- a/backend/runner/static/notebook/js/notebook_detail.js
+++ b/backend/runner/static/notebook/js/notebook_detail.js
@@ -562,7 +562,7 @@ const notebookDetail = {
         job.cancelled = false;
         this.currentRun = job;
         this.executeQueueJob(job).then((status) => {
-            if (job.stopQueueOnError && status === 'error') {
+            if (job.stopQueueOnError && status !== 'success') {
                 this.cellQueue = this.cellQueue.filter((queuedJob) => !queuedJob.stopQueueOnError);
             }
         }).finally(() => {
@@ -619,7 +619,7 @@ const notebookDetail = {
         if (Number.isNaN(cellNumericId)) {
             alert('Некорректный идентификатор ячейки');
             this.setCellStatus(cellId, 'error');
-            return;
+            return 'error';
         }
 
         const sessionId = await this.ensureSession();
@@ -628,7 +628,7 @@ const notebookDetail = {
             alert('Сначала создайте сессию.');
             this.updateSessionStatus('idle', 'Сессия не создана. Создайте новую.');
             this.setCellStatus(cellId, 'error');
-            return;
+            return 'error';
         }
 
         const code = textarea.value;
@@ -3573,10 +3573,11 @@ async handleImportFile(file) {
 
 };
 const runAll = function() {
-    const cells = document.querySelectorAll('.cell')
+    const cells = document.querySelectorAll('.cell[data-cell-type="code"]')
     for (const cell of cells) {
         const id = cell.getAttribute('data-cell-id');
         if (!id) continue;
+        if (!cell.querySelector('[data-action="run-cell"]')) continue;
 
         notebookDetail.enqueueCellRun(id, { stopQueueOnError: true });
     }

--- a/frontend/src/pages/NotebookPage.vue
+++ b/frontend/src/pages/NotebookPage.vue
@@ -945,6 +945,12 @@ const buildStructuredOutput = (result, options = {}) => {
   })
 }
 
+const didCellRunFail = (model) => {
+  if (!model) return false
+  const status = String(model.status || '').toLowerCase()
+  return status === 'error' || status === 'failed' || Boolean(model.error)
+}
+
 const serializeOutputModel = (model) => {
   return `${OUTPUT_STORAGE_PREFIX}${JSON.stringify(model)}`
 }
@@ -1265,8 +1271,8 @@ const structuredOutputToText = (model) => {
 
 const runCodeCell = async (cell, options = {}) => {
   const { refreshFiles = true } = options
-  if (runAllInProgress.value && !options.fromRunAll) return
-  if (!cell?.id || cell.cell_type !== 'code' || !canRunCells.value || isCellRunning(cell.id)) return
+  if (runAllInProgress.value && !options.fromRunAll) return null
+  if (!cell?.id || cell.cell_type !== 'code' || !canRunCells.value || isCellRunning(cell.id)) return null
   setCellRunning(cell.id, true)
   const startedAt = typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now()
   try {
@@ -1284,6 +1290,12 @@ const runCodeCell = async (cell, options = {}) => {
     await saveCodeCell(notebookId.value, cell.id, content, outputPayload)
     if (refreshFiles) {
       await refreshSessionFiles({ silent: true })
+    }
+    return {
+      cellId: cell.id,
+      ok: !didCellRunFail(outputModel),
+      status: outputModel.status,
+      outputModel,
     }
   } catch (error) {
     const message = error?.message || 'Не удалось выполнить ячейку.'
@@ -1304,6 +1316,12 @@ const runCodeCell = async (cell, options = {}) => {
     } catch (_) {
       // No-op: local output is still shown.
     }
+    return {
+      cellId: cell.id,
+      ok: false,
+      status: outputModel.status,
+      outputModel,
+    }
   } finally {
     setCellRunning(cell.id, false)
   }
@@ -1318,7 +1336,10 @@ const runAllCodeCells = async () => {
     const codeCells = orderedCells.value.filter((cell) => cell.cell_type === 'code')
     for (const cell of codeCells) {
       await waitForCellIdle(cell.id)
-      await runCodeCell(cell, { refreshFiles: false, fromRunAll: true })
+      const result = await runCodeCell(cell, { refreshFiles: false, fromRunAll: true })
+      if (result?.ok === false) {
+        break
+      }
     }
     await refreshSessionFiles({ silent: true })
   } finally {
@@ -1805,7 +1826,7 @@ const isErrorOutput = (cell) => {
   if (!cell?.output || typeof cell.output !== 'string') return false
   const model = getCellOutputModel(cell)
   if (model?.kind === 'structured') {
-    return model.status === 'error' || Boolean(model.error)
+    return didCellRunFail(model)
   }
   const text = cell.output.toLowerCase()
   return text.includes('error') || text.includes('exception') || text.includes('traceback')


### PR DESCRIPTION
﻿## Summary
- Stop Vue notebook Run All after the first cell that returns an error status or throws during execution.
- Return per-cell execution results from `runCodeCell` so batch execution can make a deterministic stop decision without changing single-cell runs.
- Apply the same stop-on-error behavior to the legacy server-rendered notebook queue.

## Why
Run All previously continued through later cells even after an earlier cell failed, which could execute dependent code with invalid state.

Closes #750

## Validation
- `npm run build`
- `node --check backend/runner/static/notebook/js/notebook_detail.js`
- `docker compose exec -T backend python manage.py test runner.api.views.test_run_cell --keepdb`
- `git diff --check`
