### PR TITLE
Auto-refresh recent submissions

### DIFF
--- a/backend/runner/api/views/submissions.py
+++ b/backend/runner/api/views/submissions.py
@@ -148,7 +148,7 @@ class MySubmissionsListView(generics.ListAPIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
-        return Submission.objects.filter(user=self.request.user).order_by("-submitted_at")
+        return Submission.objects.select_related("problem").filter(user=self.request.user).order_by("-submitted_at")
 
 
 class SubmissionDetailView(generics.RetrieveAPIView):
@@ -210,7 +210,7 @@ class ProblemSubmissionsListView(generics.ListAPIView):
         except Problem.DoesNotExist:
             return Submission.objects.none()
 
-        return Submission.objects.filter(
+        return Submission.objects.select_related("problem").filter(
             user=self.request.user,
             problem=problem
         ).order_by("-submitted_at")

--- a/frontend/src/api/submission.js
+++ b/frontend/src/api/submission.js
@@ -64,3 +64,10 @@ export async function getProblemSubmissions(problemId, page = 1) {
     credentials: 'include'
   })
 }
+
+export async function getMySubmissions() {
+  return await fetchJsonWithFriendlyErrors('/api/submissions/mine/', {
+    method: 'GET',
+    credentials: 'include'
+  })
+}

--- a/frontend/src/pages/ProblemPage.vue
+++ b/frontend/src/pages/ProblemPage.vue
@@ -257,7 +257,10 @@ const nowTs = ref(Date.now())
 let clockTimer = null
 let contestSyncTimer = null
 const contestSyncInFlight = ref(false)
+let latestSubmissionsTimer = null
+const latestSubmissionsInFlight = ref(false)
 let problemLoadRequestId = 0
+const LATEST_SUBMISSIONS_REFRESH_MS = 5000
 
 const renderStatement = (statement) => renderProblemStatement(statement)
 
@@ -427,11 +430,42 @@ const syncContestContextSilently = async () => {
   }
 }
 
+const refreshLatestSubmissions = async () => {
+  if (!isAuthorized.value || !problem.value?.id) return
+  if (latestSubmissionsInFlight.value) return
+  if (typeof document !== 'undefined' && document.hidden) return
+
+  const problemId = Number(route.params.id)
+  const currentId = Number(problem.value.id)
+  if (!Number.isInteger(problemId) || problemId !== currentId) return
+
+  latestSubmissionsInFlight.value = true
+  try {
+    const data = await getProblem(problemId, { contestId: contestIdFromQuery.value })
+    if (Number(route.params.id) !== problemId || !problem.value) return
+    problem.value = {
+      ...problem.value,
+      submissions: Array.isArray(data?.submissions) ? data.submissions : [],
+    }
+  } catch (_) {
+    // Keep the current list on transient refresh errors.
+  } finally {
+    latestSubmissionsInFlight.value = false
+  }
+}
+
 onMounted(() => {
   if (contestSyncTimer != null) return
   contestSyncTimer = window.setInterval(() => {
     void syncContestContextSilently()
   }, 5000)
+})
+
+onMounted(() => {
+  if (latestSubmissionsTimer != null) return
+  latestSubmissionsTimer = window.setInterval(() => {
+    void refreshLatestSubmissions()
+  }, LATEST_SUBMISSIONS_REFRESH_MS)
 })
 
 onBeforeUnmount(() => {
@@ -442,6 +476,10 @@ onBeforeUnmount(() => {
   if (contestSyncTimer != null) {
     window.clearInterval(contestSyncTimer)
     contestSyncTimer = null
+  }
+  if (latestSubmissionsTimer != null) {
+    window.clearInterval(latestSubmissionsTimer)
+    latestSubmissionsTimer = null
   }
 })
 
@@ -686,13 +724,8 @@ const handleSubmit = async () => {
     await submitSolution(problem.value.id, payload)
     submitMessage.value = { type: 'success', text: 'Решение успешно отправлено на проверку!' }
     
-    // Refresh problem data to show new submission
     try {
-      const res = await getProblem(route.params.id, { contestId: contestIdFromQuery.value })
-      problem.value = res
-      if (problem.value != null) {
-        problem.value.rendered_statement = renderStatement(problem.value.statement)
-      }
+      await refreshLatestSubmissions()
     } catch (refreshError) {
       console.warn('Failed to refresh submissions after upload:', refreshError)
       submitMessage.value = {

--- a/frontend/src/pages/ProfilePage.vue
+++ b/frontend/src/pages/ProfilePage.vue
@@ -258,9 +258,12 @@
 
 <script>
 import { getCurrentProfile, updateProfileInfo, uploadProfileAvatar } from '@/api/profile'
+import { getMySubmissions } from '@/api/submission'
 import { useUserStore } from '@/stores/UserStore'
 import UiHeader from '@/components/ui/UiHeader.vue'
 import UiBreadcrumbs from '@/components/ui/UiBreadcrumbs.vue'
+
+const RECENT_SUBMISSIONS_REFRESH_MS = 5000
 
 export default {
   name: 'ProfilePage',
@@ -279,6 +282,8 @@ export default {
       editFirstName: '',
       editLastName: '',
       activityYearLoading: false,
+      submissionsRefreshTimer: null,
+      submissionsRefreshInFlight: false,
       userStore: null
     }
   },
@@ -594,6 +599,41 @@ export default {
       this.$router.push(`/submission/${submissionId}/`)
     },
 
+    normalizeSubmissionList(payload) {
+      if (Array.isArray(payload)) return payload
+      if (Array.isArray(payload?.results)) return payload.results
+      if (Array.isArray(payload?.submissions)) return payload.submissions
+      return []
+    },
+
+    async refreshRecentSubmissions() {
+      if (!this.isAuthenticated || this.submissionsRefreshInFlight) return
+      if (typeof document !== 'undefined' && document.hidden) return
+
+      this.submissionsRefreshInFlight = true
+      try {
+        const data = await getMySubmissions()
+        this.submissions = this.normalizeSubmissionList(data).slice(0, 4)
+      } catch (_) {
+        // Keep the current list on transient refresh errors.
+      } finally {
+        this.submissionsRefreshInFlight = false
+      }
+    },
+
+    startSubmissionsPolling() {
+      if (this.submissionsRefreshTimer != null) return
+      this.submissionsRefreshTimer = window.setInterval(() => {
+        this.refreshRecentSubmissions()
+      }, RECENT_SUBMISSIONS_REFRESH_MS)
+    },
+
+    stopSubmissionsPolling() {
+      if (this.submissionsRefreshTimer == null) return
+      window.clearInterval(this.submissionsRefreshTimer)
+      this.submissionsRefreshTimer = null
+    },
+
     triggerFileUpload() {
       this.$refs.fileInput.click()
     },
@@ -696,6 +736,10 @@ export default {
   },
   mounted() {
     this.loadProfileData()
+    this.startSubmissionsPolling()
+  },
+  beforeUnmount() {
+    this.stopSubmissionsPolling()
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- Auto-refresh the recent submissions block on problem pages every 5 seconds while the tab is visible.
- Auto-refresh the recent submissions list on the profile page from the existing `/api/submissions/mine/` endpoint.
- Avoid overlapping refresh requests and keep the current list on transient network errors.
- Add `select_related(problem)` for submission list APIs used by polling.

## Verification
- npm run lint
- npm run build
- docker exec booml-backend python manage.py test runner.api.views.test_submissions --keepdb -v 2

Closes #590